### PR TITLE
InGameUI -> Lives Counter, score tracker, UI styling

### DIFF
--- a/scenes/Game.js
+++ b/scenes/Game.js
@@ -8,7 +8,14 @@ export default class GameScene extends Phaser.Scene {
 
     create() {
 
+        /*
+        * Launching the scene so the ingameUI can be scene while the game is being played
+        * this.score & visitedTiles is needed in order to record the score
+        */
         this.scene.launch('GameUI')
+        this.score = 0;
+        this.visitedTiles = new Set();
+
         // Create tilemap
         this.map = this.make.tilemap({ key: "map" });
         const tileset = this.map.addTilesetImage("ground_tiles", "tiles");
@@ -122,7 +129,18 @@ export default class GameScene extends Phaser.Scene {
 
     updateTile(map) {
         let currentTile = this.getPlayerTile(map, this.player.direction);
+
         if (currentTile) {
+
+            const tileKey = `${currentTile.x},${currentTile.y}`;
+            // If this tile hasn't been discovered yet, add to set and give points
+            if (!this.visitedTiles.has(tileKey)) {
+                this.visitedTiles.add(tileKey);
+                this.score += 10;
+
+                // Emit score update to UI
+                this.game.events.emit("updateScore", this.score);
+            }
             this.changeTileTexture(map, currentTile, this.player.direction);
             this.player.lastTile = currentTile;
         }

--- a/scenes/Game.js
+++ b/scenes/Game.js
@@ -11,10 +11,12 @@ export default class GameScene extends Phaser.Scene {
         /*
         * Launching the scene so the ingameUI can be scene while the game is being played
         * this.score & visitedTiles is needed in order to record the score
+        * this.highScore needed to save the score to localstorage if currentscore surpasses highscore
         */
         this.scene.launch('GameUI')
         this.score = 0;
         this.visitedTiles = new Set();
+        this.highScore = parseInt(localStorage.getItem("highScore")) || 0;
 
         // Create tilemap
         this.map = this.make.tilemap({ key: "map" });
@@ -159,6 +161,12 @@ export default class GameScene extends Phaser.Scene {
             });
     
             if (this.lives <= 0) {
+
+                // Save high score to localStorage
+                const prevHighScore = parseInt(localStorage.getItem("highScore")) || 0;
+                if (this.score > prevHighScore) {
+                    localStorage.setItem("highScore", this.score);
+                }
                 this.scene.stop('GameUI');
                 this.scene.restart();
             }
@@ -181,8 +189,18 @@ export default class GameScene extends Phaser.Scene {
                 this.visitedTiles.add(tileKey);
                 this.score += 10;
 
-                
                 this.game.events.emit("updateScore", this.score);
+
+                // Check if new high score
+                if (this.score > this.highScore) {
+                    this.highScore = this.score;
+
+                    // Save new high score to localStorage
+                    localStorage.setItem("highScore", this.highScore);
+
+                    // Emit update to GameUI
+                    this.game.events.emit("updateHighScore", this.highScore);
+                }
             }
             this.changeTileTexture(map, currentTile, this.player.direction);
             this.player.lastTile = currentTile;

--- a/scenes/GameUI.js
+++ b/scenes/GameUI.js
@@ -10,11 +10,17 @@ export default class GameUI extends Phaser.Scene {
         const scaleX = 630; 
         const scaleY = 35;
 
+        // other optional choice of slightly darker blue -> #242957
+        const outlineColor = "#343d94" // Controls the outline color that surrounds the text"
+        const outlineThickness = 5; // higher value means thicker outline
+
         // Display "Player Lives:" text -> Partially completed
         const livesText = this.add.text(scaleX, scaleY, "Lives:", {
             fontSize: "25px",
             fill: "#ffffff",
-            fontFamily: 'PressStart2P'
+            fontFamily: 'PressStart2P',
+            stroke: outlineColor, 
+            strokeThickness: outlineThickness
         });
 
         const maxLives = 3;
@@ -40,29 +46,51 @@ export default class GameUI extends Phaser.Scene {
                 icon.setVisible(index < newLives);
             });
         });
-        
-        
-        // highScore, currentscore, & powerUps Text -> functionality incomplete
+
+        /*
+        * HighScore that changes when a player surpasses his highscore
+        * Will change in realtime if player surpasses his highscore and is still alive
+        */
         const highScoreText = this.add.text(scaleX, scaleY + 100, "High\nScore:", {
             fontSize: "25px",
             fill: "#ffffff",
-            fontFamily: 'PressStart2P'
+            fontFamily: 'PressStart2P',
+            stroke: outlineColor, 
+            strokeThickness: outlineThickness
+        });
+        const highScoreValue = parseInt(localStorage.getItem("highScore")) || 0;
+        
+        this.highScoreValueText = this.add.text(scaleX, scaleY + 175, highScoreValue.toString(), {
+            fontSize: "25px",
+            fill: "#ffffff",
+            fontFamily: 'PressStart2P',
+            stroke: outlineColor, 
+            strokeThickness: outlineThickness
+        });
+
+        this.game.events.on("updateHighScore", (newHighScore) => {
+            if (this.highScoreValueText?.setText) {
+                this.highScoreValueText.setText(newHighScore.toString());
+            }
         });
 
         const currentScoreText = this.add.text(scaleX, scaleY + 250, "Current\nScore:", {
             fontSize: "25px",
             fill: "#ffffff",
-            fontFamily: 'PressStart2P'
+            fontFamily: 'PressStart2P',
+            stroke: outlineColor, 
+            strokeThickness: outlineThickness
         });
 
         /*
         * Score that dynamically changes when a player talks over the tile
-        *
         */
         this.score = this.add.text(scaleX, scaleY + 315, "0", {
             fontSize: "25px",
             fill: "#ffffff",
-            fontFamily: 'PressStart2P'
+            fontFamily: 'PressStart2P',
+            stroke: outlineColor, 
+            strokeThickness: outlineThickness
         });
 
         this.game.events.on("updateScore", (newScore) => {
@@ -71,11 +99,23 @@ export default class GameUI extends Phaser.Scene {
             }
         });
 
+        /*
+        * Functionality for showPowerUps and showing the Level your on is incomplete
+        */
         const showPowerUps = this.add.text(scaleX, scaleY + 400, "Active\nPowers:", {
             fontSize: "25px",
             fill: "#ffffff",
-            fontFamily: 'PressStart2P'
+            fontFamily: 'PressStart2P',
+            stroke: outlineColor, 
+            strokeThickness: outlineThickness
         });
 
+        const levelText = this.add.text(scaleX, scaleY + 700, "Level: ", {
+            fontSize: "25px",
+            fill: "#ffffff",
+            fontFamily: 'PressStart2P',
+            stroke: outlineColor, 
+            strokeThickness: outlineThickness
+        });
     }
 }

--- a/scenes/GameUI.js
+++ b/scenes/GameUI.js
@@ -36,13 +36,27 @@ export default class GameUI extends Phaser.Scene {
             fontFamily: 'PressStart2P'
         });
 
-        const currentScoreText = this.add.text(scaleX, scaleY + 225, "Current\nScore:", {
+        const currentScoreText = this.add.text(scaleX, scaleY + 250, "Current\nScore:", {
             fontSize: "25px",
             fill: "#ffffff",
             fontFamily: 'PressStart2P'
         });
 
-        const showPowerUps = this.add.text(scaleX, scaleY + 350, "Active\nPowers:", {
+        /*
+        * Score that dynamically changes when a player talks over the tile
+        *
+        */
+        const score = this.add.text(scaleX, scaleY + 315, "0", {
+            fontSize: "25px",
+            fill: "#ffffff",
+            fontFamily: 'PressStart2P'
+        });
+
+        this.game.events.on("updateScore", (newScore) => {
+            score.setText(newScore.toString());
+        });
+
+        const showPowerUps = this.add.text(scaleX, scaleY + 400, "Active\nPowers:", {
             fontSize: "25px",
             fill: "#ffffff",
             fontFamily: 'PressStart2P'

--- a/scenes/GameUI.js
+++ b/scenes/GameUI.js
@@ -22,12 +22,25 @@ export default class GameUI extends Phaser.Scene {
         const livesX = 650; 
         const livesY = 85;
 
+        /*
+        * Lives are stored in an array that is changed when a game event is emitted (player is hit by enemy)
+        */
+        this.livesIcons = []; // Store references for later updates
+
         for (let i = 0; i < maxLives; i++) {
-            this.add.image(livesX + (i * lifeSpacing), livesY, 'player')
+            const icon = this.add.image(livesX + (i * lifeSpacing), livesY, 'player')
                 .setScale(0.5)
                 .setOrigin(0.5)
                 .setFrame(0);
+        
+            this.livesIcons.push(icon); // Save each icon
         }
+        this.game.events.on("updateLives", (newLives) => {
+            this.livesIcons.forEach((icon, index) => {
+                icon.setVisible(index < newLives);
+            });
+        });
+        
         
         // highScore, currentscore, & powerUps Text -> functionality incomplete
         const highScoreText = this.add.text(scaleX, scaleY + 100, "High\nScore:", {
@@ -46,14 +59,16 @@ export default class GameUI extends Phaser.Scene {
         * Score that dynamically changes when a player talks over the tile
         *
         */
-        const score = this.add.text(scaleX, scaleY + 315, "0", {
+        this.score = this.add.text(scaleX, scaleY + 315, "0", {
             fontSize: "25px",
             fill: "#ffffff",
             fontFamily: 'PressStart2P'
         });
 
         this.game.events.on("updateScore", (newScore) => {
-            score.setText(newScore.toString());
+            if (this.score?.setText) {
+                this.score.setText(newScore.toString());
+            }
         });
 
         const showPowerUps = this.add.text(scaleX, scaleY + 400, "Active\nPowers:", {


### PR DESCRIPTION
Completed functionality of Lives Counter, current/highscore tracker, and added a blue stroke to the outline of the words. Whats next to be worked on is displaying what level you are on and if time permits, getting the out of scope feature of powerUps to work.

Proper code documentation was added to all new functions that were implemented in GameUI.js and Gamescene