### PR TITLE
Update Enemy Movement and Fix Issues

### DIFF
--- a/entities/Player.js
+++ b/entities/Player.js
@@ -9,6 +9,8 @@ export default class player extends Phaser.Physics.Arcade.Sprite {
         this.displayHeight = 50;
         this.direction = null;
         this.depth = 1;
+
+        this.lastTile = this.scene.map.getTileAtWorldXY(x, y);
     }
 
     handleInput(cursors, wasdKeys) {

--- a/scenes/Game.js
+++ b/scenes/Game.js
@@ -109,7 +109,9 @@ export default class GameScene extends Phaser.Scene {
         this.player.handleInput(this.cursors, this.wasdKeys);
 
         this.enemyGroup.getChildren().forEach(enemy => {
-            enemy.update(this.player);
+            if (enemy.isActive) {
+                enemy.update(this.player);
+            }
         });
 
         this.rockGroup.getChildren().forEach(rock => {
@@ -236,7 +238,10 @@ export default class GameScene extends Phaser.Scene {
 
     handleRockHitEntity(entity, rock) {
         if (entity == this.player) { this.handlePlayerHit(entity); }
-        else { entity.destroy(); }
+        else {
+            entity.isActive = false;
+            entity.destroy();
+        }
         rock.destroy();
     }
 


### PR DESCRIPTION
Fixed an issue that crashed the game when enemies would die to rocks.
Fixedan issue that crashed the game when an enemy's direction would return null.
Made enemies properly move within partially dug out tiles. For example, if a tile is half dug out, an enemy will only move half way into the tile.