### PR TITLE
Fixed crashing issue when player moved to the right and bottom borders

### DIFF
--- a/entities/Enemy.js
+++ b/entities/Enemy.js
@@ -235,19 +235,20 @@ export default class enemy extends Phaser.Physics.Arcade.Sprite {
                 tileCoords = this.scene.map.worldToTileXY(player.getCenter().x - 25, player.getCenter().y);
                 break;
             case 'right':
-                tileCoords = this.scene.map.worldToTileXY(player.getCenter().x + 25, player.getCenter().y);
+                tileCoords = this.scene.map.worldToTileXY(player.getCenter().x + 24, player.getCenter().y);
                 break;
             case 'up':
                 tileCoords = this.scene.map.worldToTileXY(player.getCenter().x, player.getCenter().y - 25);
                 break;
             case 'down':
-                tileCoords = this.scene.map.worldToTileXY(player.getCenter().x, player.getCenter().y + 25);
+                tileCoords = this.scene.map.worldToTileXY(player.getCenter().x, player.getCenter().y + 24);
                 break;
             default:
                 tileCoords = this.scene.map.worldToTileXY(player.getCenter().x, player.getCenter().y);
                 break;
         }
         const playerTile = this.scene.map.getTileAt(tileCoords.x, tileCoords.y, false, this.scene.map.groundLayer);
+
 
         if (!currentTile || !playerTile) return null;
 


### PR DESCRIPTION
The issue occurred due to the 50x50 pixel nature of the tiles. The getNextDirectionInPath function would get the wrong tile the player was currently in when the player was moving down or right. Therefore, once the player was on the right or bottom border, the function tried to get a tile that did not exist (it was outside the tilemap's scope).

The fix was reducing how far to look ahead from the player's center position.